### PR TITLE
Corrigir o nome das funções do modelo `migrator`.

### DIFF
--- a/model/migrator.js
+++ b/model/migrator.js
@@ -10,7 +10,7 @@ const defaultMigrationOptions = {
   migrationsTable: "pgmigrations",
 };
 
-async function listPendindMigrations() {
+async function listPendingMigrations() {
   let dbClient;
 
   try {
@@ -27,7 +27,7 @@ async function listPendindMigrations() {
   }
 }
 
-async function runPendindMigrations() {
+async function runPendingMigrations() {
   let dbClient;
 
   try {
@@ -46,8 +46,8 @@ async function runPendindMigrations() {
 }
 
 const migrator = {
-  listPendindMigrations,
-  runPendindMigrations,
+  listPendingMigrations,
+  runPendingMigrations,
 };
 
 export default migrator;

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -10,12 +10,12 @@ router.post(postHandler);
 export default router.handler(controller.errorHandlers);
 
 async function getHandler(request, response) {
-  const pendingMigrations = await migrator.listPendindMigrations();
+  const pendingMigrations = await migrator.listPendingMigrations();
   return response.status(200).json(pendingMigrations);
 }
 
 async function postHandler(request, response) {
-  const migratedMigrations = await migrator.runPendindMigrations();
+  const migratedMigrations = await migrator.runPendingMigrations();
 
   if (migratedMigrations.length > 0) {
     return response.status(201).json(migratedMigrations);

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -26,7 +26,7 @@ async function clearDatabase() {
 }
 
 async function runPendingMigrations() {
-  await migrator.runPendindMigrations();
+  await migrator.runPendingMigrations();
 }
 
 const orchestrator = {


### PR DESCRIPTION
- Corrigi o nome da funções: 
  - `runPendindMigrations` para `runPendingMigrations`
  - `listPendindMigrations` para `listPendingMigrations`